### PR TITLE
updated typings to match highcharts v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "zone.js": "0.6.25"
   },
   "dependencies": {
-    "@types/highcharts": "^4.2.36",
-    "highcharts": "^4.2.7"
+    "@types/highcharts": "^4.2.5",
+    "highcharts": "^5.0.2"
   }
 }


### PR DESCRIPTION
Just to fix #93 by upgrading to highcharts v5.

Read through the changelogs of highcharts `v5.0.0`, `v5.0.1` and `v5.0.2`, no changes except additional options features. Tested on my local projects, everything works fine. For the real implementation of other changelogs of version ^5.0.0, yet to dive in to put in the meat  
