### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Any other modules like highcharts-3d, highcharts-exporintg and etc. can be also 
       BrowserModule, 
       ChartModule.forRoot(
         require('highcharts'),
-+       require('highcharts/highchart-3d'),
++       require('highcharts/highcharts-3d'),
 +       require('highcharts/modules/exporting')
       )
     ],


### PR DESCRIPTION
Wrong path is causing problems to users that want to use 3d charts.
Before: 'highcharts/highchart-3d'
After:    'highcharts/highcharts-3d'