### PR TITLE
Destroy highchart upon component disploal

### DIFF
--- a/src/ChartComponent.spec.ts
+++ b/src/ChartComponent.spec.ts
@@ -55,15 +55,29 @@ export function main() {
             });
         };
 
-        it('should create simple chart object', (done) => {
+        it('should create/destroy simple chart object', (done) => {
             create('<chart [options]="options"></chart>').then(fixture => {
                 fixture.componentInstance.options = ['options'];
-                spyOn(highchartsServiceMock.getHighchartsStatic(), 'Chart');
+
+		const RealChart = highchartsServiceMock.getHighchartsStatic().Chart;
+
+		let destroySpy;
+
+                const chartSpy = spyOn(highchartsServiceMock.getHighchartsStatic(), 'Chart')
+                    .and.callFake(opts => {
+			const chart = new RealChart(opts);
+			destroySpy = spyOn(chart, 'destroy');
+			return chart;
+                    });
 
                 fixture.detectChanges();
-                expect(highchartsServiceMock.getHighchartsStatic().Chart).toHaveBeenCalled();
+                expect(chartSpy).toHaveBeenCalled();
+
+
+		fixture.destroy();
+		expect(destroySpy).toHaveBeenCalled();
                 done();
-            })
+            });
         });
 
         it('should emit the "create" event with HighchartsChartObject', (done) => {

--- a/src/ChartComponent.ts
+++ b/src/ChartComponent.ts
@@ -1,4 +1,4 @@
-import { Input, ElementRef, Component, Output, EventEmitter, ContentChild } from '@angular/core';
+import { AfterViewInit, Input, ElementRef, Component, OnDestroy, Output, EventEmitter, ContentChild } from '@angular/core';
 
 import { ChartSeriesComponent } from './ChartSeriesComponent';
 import { ChartXAxisComponent } from './ChartXAxisComponent';
@@ -13,7 +13,7 @@ import { createBaseOpts } from './createBaseOpts';
     template: '&nbsp;',
     providers: [HighchartsService],
 })
-export class ChartComponent {
+export class ChartComponent implements AfterViewInit, OnDestroy {
     @ContentChild(ChartSeriesComponent) series: ChartSeriesComponent;
     @ContentChild(ChartXAxisComponent) xAxis: ChartXAxisComponent;
     @ContentChild(ChartYAxisComponent) yAxis: ChartYAxisComponent;
@@ -45,9 +45,13 @@ export class ChartComponent {
         }
     }
 
-    ngAfterViewInit() {
+    public ngAfterViewInit() {
         this.baseOpts = createBaseOpts(this, this.series, this.series ? this.series.point : null, this.xAxis, this.yAxis, this.element.nativeElement);
         this.init();
+    }
+
+    public ngOnDestroy() {
+	if(this.chart) this.chart.destroy();
     }
 
     constructor(element: ElementRef, highchartsService : HighchartsService) {

--- a/src/Mocks.ts
+++ b/src/Mocks.ts
@@ -28,6 +28,8 @@ export class HighchartsChartObjectMock {
     constructor (_opts) {
         opts = _opts;
     }
+
+    public destroy() {}
 }
 const highchartsStatic =  {
     Chart : HighchartsChartObjectMock,


### PR DESCRIPTION
As stated in #224, we should call destroy function on highcharts when the angular component is destroyed. Otherwise this will lead to a memory leak.